### PR TITLE
Verify that a token is not cached for failed auth and is cached for successful auth

### DIFF
--- a/lib/ueberauth_token/strategy.ex
+++ b/lib/ueberauth_token/strategy.ex
@@ -274,7 +274,7 @@ defmodule UeberauthToken.Strategy do
       conn
     else
       {:ok, payload} ->
-        Conn.put_private(conn, :ueberauth_token, %{ueberauth_token | payload: payload})
+        Conn.put_private(conn, :ueberauth_token, Map.put(ueberauth_token, :payload, payload))
 
       false ->
         conn

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule UeberauthToken.MixProject do
 
   defp aliases do
     [
-      prepare: ["deps.get", "clean", "format", "compile", "credo --strict"]
+      prepare: ["deps.get", "clean", "format", "compile", "credo --strict"],
+      test: ["test --no-start"]
     ]
   end
 

--- a/test/fixtures/ueberauth_token.exs
+++ b/test/fixtures/ueberauth_token.exs
@@ -124,4 +124,30 @@ defmodule UeberauthToken.Fixtures do
       strategy: UeberauthToken.Strategy
     }
   end
+
+  def payload do
+    %UeberauthToken.TestProvider.Payload{
+      avatar: nil,
+      description: nil,
+      email: "johndoe@quiqup.com",
+      expires_in: 10,
+      first_name: "John",
+      last_name: "Doe",
+      location: "London",
+      name: "John Doe",
+      other_token_info: %{},
+      phone: nil,
+      provider: UeberauthToken.TestProvider,
+      refresh_token: nil,
+      scopes: ["read", "write"],
+      secret: nil,
+      token: "5a236016-07f0-4689-bf74-d7b8559b21d7",
+      token_type: "Bearer",
+      urls: %{
+        "homepage" => "https://www.quiqup.com/"
+      },
+      user_id: 1,
+      username: "john_d"
+    }
+  end
 end

--- a/test/support/expectations_test_helpers.ex
+++ b/test/support/expectations_test_helpers.ex
@@ -7,7 +7,7 @@ defmodule UeberauthToken.ExpectationTestHelpers do
   @passing_token_payload "test/fixtures/passing/token_payload.json"
   @failing_user_payload "test/fixtures/failing/user_payload.json"
   @failing_token_payload "test/fixtures/failing/token_payload.json"
-  @passing_auth_module_path "test/fixtures/ueberauth.exs"
+  @passing_auth_module_path "test/fixtures/ueberauth_token.exs"
   @passing_token_string "5a236016-07f0-4689-bf74-d7b8559b21d7"
   @failing_token_string "5a236016-07f0-4689-bf74-d7b8559b21d8"
   @expires_in 10

--- a/test/support/setup_test_helpers.ex
+++ b/test/support/setup_test_helpers.ex
@@ -1,6 +1,14 @@
 defmodule UeberauthToken.SetupTestHelpers do
   @moduledoc false
-  import UeberauthToken.ExpectationTestHelpers, only: [failing_token: 0, passing_token: 0]
+  import UeberauthToken.ExpectationTestHelpers,
+    only: [
+      failing_token: 0,
+      passing_token: 0,
+      expect_passing_token_info: 0,
+      expect_passing_user_info: 0
+    ]
+
+  import UeberauthToken, only: [token_auth: 3]
   alias UeberauthToken.ConfigTestHelpers
   alias Plug.Conn
 
@@ -16,6 +24,13 @@ defmodule UeberauthToken.SetupTestHelpers do
 
   def ensure_cache_and_background_worker_activated(context) do
     ConfigTestHelpers.ensure_activated_cache_and_background_worker()
+    context
+  end
+
+  def ensure_token_is_cached(
+        %{conn: %{private: %{ueberauth_token: %{provider: provider}}}} = context
+      ) do
+    token_auth(passing_token(), provider, validate_provider: false)
     context
   end
 
@@ -46,10 +61,7 @@ defmodule UeberauthToken.SetupTestHelpers do
   def setup_valid_private_ueberauth_token(%{conn: conn} = context) do
     %{
       context
-      | conn:
-          Conn.put_private(conn, :ueberauth_token, %{
-            token: %{"authorization" => "Bearer #{passing_token()}"}
-          }),
+      | conn: put_private_token(conn, "Bearer #{passing_token()}"),
         token: passing_token()
     }
   end
@@ -57,10 +69,7 @@ defmodule UeberauthToken.SetupTestHelpers do
   def setup_empty_private_ueberauth_token(%{conn: conn} = context) do
     %{
       context
-      | conn:
-          Conn.put_private(conn, :ueberauth_token, %{
-            token: %{"authorization" => ""}
-          }),
+      | conn: put_private_token(conn, ""),
         token: ""
     }
   end
@@ -68,10 +77,7 @@ defmodule UeberauthToken.SetupTestHelpers do
   def setup_failing_private_ueberauth_token(%{conn: conn} = context) do
     %{
       context
-      | conn:
-          Conn.put_private(conn, :ueberauth_token, %{
-            token: %{"authorization" => "Bearer #{failing_token()}"}
-          }),
+      | conn: put_private_token(conn, "Bearer #{failing_token()}"),
         token: failing_token()
     }
   end
@@ -98,8 +104,48 @@ defmodule UeberauthToken.SetupTestHelpers do
 
     %{
       context
-      | conn: Conn.put_private(conn, :ueberauth_token, %{provider: provider}),
+      | conn: put_provider(conn, provider),
         provider: provider
     }
+  end
+
+  def setup_activated_cache(context) do
+    expect_passing_token_info()
+    expect_passing_user_info()
+
+    context
+    |> ensure_cache_activated()
+    |> setup_provider()
+    |> ensure_token_is_cached()
+  end
+
+  def put_provider(%Conn{private: %{ueberauth_token: ueberauth_token}} = conn) do
+    provider = ConfigTestHelpers.test_provider()
+    Conn.put_private(conn, :ueberauth_token, Map.put(ueberauth_token, :provider, provider))
+  end
+
+  def put_provider(%Conn{} = conn) do
+    provider = ConfigTestHelpers.test_provider()
+    Conn.put_private(conn, :ueberauth_token, %{provider: provider})
+  end
+
+  def put_provider(%Conn{private: %{ueberauth_token: ueberauth_token}} = conn, provider) do
+    Conn.put_private(conn, :ueberauth_token, Map.put(ueberauth_token, :provider, provider))
+  end
+
+  def put_provider(%Conn{} = conn, provider) do
+    Conn.put_private(conn, :ueberauth_token, %{provider: provider})
+  end
+
+  def put_private_token(%Conn{private: %{ueberauth_token: ueberauth_token}} = conn, token) do
+    Conn.put_private(
+      conn,
+      :ueberauth_token,
+      Map.put(ueberauth_token, :token, %{"authorization" => "#{token}"})
+    )
+  end
+
+  def put_private_token(%Conn{} = conn, token) do
+    Conn.put_private(conn, :ueberauth_token, %{token: %{"authorization" => "#{token}"}})
   end
 end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -18,6 +18,7 @@ defmodule UeberauthToken.TestCase do
       }
 
       alias Ueberauth.{Auth, Failure}
+      alias Ueberauth.Auth.Credentials
       import UeberauthToken.ConfigTestHelpers, only: [test_provider: 0]
       import UeberauthToken.ExpectationTestHelpers
       import UeberauthToken.SetupTestHelpers

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -7,7 +7,16 @@ defmodule UeberauthToken.TestCase do
   using do
     quote do
       alias Plug.Conn
-      alias UeberauthToken.{Config, Strategy, TestProvider, TestProviderMock, ConfigTestHelpers}
+
+      alias UeberauthToken.{
+        Config,
+        Fixtures,
+        Strategy,
+        TestProvider,
+        TestProviderMock,
+        ConfigTestHelpers
+      }
+
       alias Ueberauth.{Auth, Failure}
       import UeberauthToken.ConfigTestHelpers, only: [test_provider: 0]
       import UeberauthToken.ExpectationTestHelpers
@@ -17,7 +26,7 @@ defmodule UeberauthToken.TestCase do
   end
 
   setup_all do
-    :ok
+    {:ok, %{}}
   end
 
   setup do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 ExUnit.start()
 
 Application.ensure_all_started(:plug)
+Application.ensure_all_started(:mox)
 Mox.defmock(UeberauthToken.TestProviderMock, for: UeberauthToken.TestProvider)

--- a/test/ueberauth_token/plug_test.exs
+++ b/test/ueberauth_token/plug_test.exs
@@ -14,8 +14,8 @@ defmodule UeberauthToken.PlugTest do
     @describetag :token
 
     test "the plug pipeline responds and is not halted", %{conn: conn} do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       conn = TestPlugRouter.call(conn, [])
 
@@ -23,8 +23,8 @@ defmodule UeberauthToken.PlugTest do
     end
 
     test "an authenticated plug pipeline returns a cleaned private field", %{conn: conn} do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       conn = TestPlugRouter.call(conn, [])
 
@@ -32,8 +32,8 @@ defmodule UeberauthToken.PlugTest do
     end
 
     test "an authenticated plug pipeline assigns an %Auth{} struct to the conn", %{conn: conn} do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       now_unix = DateTime.to_unix(DateTime.utc_now(), :second)
       conn = TestPlugRouter.call(conn, [])
@@ -49,8 +49,8 @@ defmodule UeberauthToken.PlugTest do
       conn: conn,
       token: expected_token
     } do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       conn = TestPlugRouter.call(conn, [])
 
@@ -96,7 +96,7 @@ defmodule UeberauthToken.PlugTest do
     @describetag :token
 
     test "the plug pipeline responds and is not halted", %{conn: conn} do
-      expect_passing_user_info(1)
+      expect_passing_user_info()
       expect_failing_token_info(1)
 
       conn = TestPlugRouter.call(conn, [])
@@ -105,7 +105,7 @@ defmodule UeberauthToken.PlugTest do
     end
 
     test "an unauthenticated plug pipeline returns a cleaned private field", %{conn: conn} do
-      expect_passing_user_info(1)
+      expect_passing_user_info()
       expect_failing_token_info(1)
 
       conn = TestPlugRouter.call(conn, [])
@@ -116,7 +116,7 @@ defmodule UeberauthToken.PlugTest do
     test "an unauthenticated plug pipeline assigns an %Failure{} struct to the conn", %{
       conn: conn
     } do
-      expect_passing_user_info(1)
+      expect_passing_user_info()
       expect_failing_token_info(1)
 
       conn = TestPlugRouter.call(conn, [])

--- a/test/ueberauth_token/strategy_test.exs
+++ b/test/ueberauth_token/strategy_test.exs
@@ -79,12 +79,12 @@ defmodule UeberauthToken.StrategyTest do
          the handle_callback!/1 function returns a conn with a private payload
          in the format %Conn{private: %{ueberauth_token: payload}}
          """,
-         %{conn: conn, token: token} do
-      expect_passing_token_info(2)
-      expect_passing_user_info(2)
+         %{conn: conn} do
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       conn_after = Strategy.handle_callback!(conn)
-      {:ok, expected_payload} = TestProvider.get_payload(token)
+      expected_payload = Fixtures.payload()
 
       refute conn_after == conn
       assert Map.has_key?(conn_after.assigns, :ueberauth_failure) == false
@@ -121,12 +121,12 @@ defmodule UeberauthToken.StrategyTest do
          the handle_callback!/1 function returns a conn with a private payload
          in the format %Conn{private: %{ueberauth_token: payload}}
          """,
-         %{conn: conn, token: token} do
-      expect_passing_token_info(2)
-      expect_passing_user_info(2)
+         %{conn: conn} do
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       conn_after = Strategy.handle_callback!(conn)
-      {:ok, expected_payload} = TestProvider.get_payload(token)
+      expected_payload = Fixtures.payload()
 
       refute conn_after == conn
       assert Map.has_key?(conn_after.assigns, :ueberauth_failure) == false

--- a/test/ueberauth_token/ueberauth_token_test.exs
+++ b/test/ueberauth_token/ueberauth_token_test.exs
@@ -20,8 +20,8 @@ defmodule UeberauthToken.UeberauthTokenTest do
       token: token,
       provider: provider
     } do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       now_unix = DateTime.to_unix(DateTime.utc_now(), :second)
       {:ok, %Auth{} = actual_ueberauth_struct} = UeberauthToken.token_auth(token, provider)
@@ -35,8 +35,8 @@ defmodule UeberauthToken.UeberauthTokenTest do
       token: token,
       provider: provider
     } do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       {:ok, %Auth{} = actual_ueberauth_struct} = UeberauthToken.token_auth(token, provider)
       actual_ueberauth_token = actual_ueberauth_struct.credentials.token
@@ -64,8 +64,8 @@ defmodule UeberauthToken.UeberauthTokenTest do
       token: token,
       provider: provider
     } do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       now_unix = DateTime.to_unix(DateTime.utc_now(), :second)
       opts = [validate_provider: false]
@@ -80,8 +80,8 @@ defmodule UeberauthToken.UeberauthTokenTest do
       token: token,
       provider: provider
     } do
-      expect_passing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_token_info()
+      expect_passing_user_info()
 
       opts = [validate_provider: false]
       {:ok, %Auth{} = actual_ueberauth_struct} = UeberauthToken.token_auth(token, provider, opts)
@@ -195,7 +195,7 @@ defmodule UeberauthToken.UeberauthTokenTest do
       provider: provider
     } do
       expect_failing_token_info(1)
-      expect_passing_user_info(1)
+      expect_passing_user_info()
 
       {:error, %Failure{} = actual_ueberauth_struct} = UeberauthToken.token_auth(token, provider)
 

--- a/test/ueberauth_token/with_cache/cache_test.exs
+++ b/test/ueberauth_token/with_cache/cache_test.exs
@@ -1,0 +1,47 @@
+defmodule UeberauthToken.WithCache.CacheTest do
+  use UeberauthToken.TestCase
+
+  describe """
+  When the cache is activated and
+  when the token has been cached
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test "the cache is active" do
+      assert Config.use_cache?(test_provider()) == true
+      assert Config.cache_name(test_provider()) in :ets.all() == true
+    end
+
+    test """
+         the token is stored in the cache
+         """,
+         _context do
+      passing_token() in Cachex.keys!(:ueberauth_token_test_provider)
+    end
+
+    test """
+         the payload associated with the token is as expected
+         """,
+         _context do
+      {:ok, actual_payload} = Cachex.get(:ueberauth_token_test_provider, passing_token())
+      expected_payload = Fixtures.payload()
+
+      assert actual_payload == expected_payload
+    end
+
+    test """
+         the ttl associated with the token is as expected
+         """,
+         _context do
+      {:ok, ttl} = Cachex.ttl(:ueberauth_token_test_provider, passing_token())
+
+      assert ttl > 0 and ttl < 10_000
+    end
+  end
+end

--- a/test/ueberauth_token/with_cache/plug_test.exs
+++ b/test/ueberauth_token/with_cache/plug_test.exs
@@ -1,0 +1,242 @@
+defmodule UeberauthToken.WithCache.PlugTest do
+  use UeberauthToken.TestCase
+  alias UeberauthToken.TestPlugRouter
+  alias Plug.Conn.TokenParsingError
+  alias Plug.Test
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when the request headers have a valid authorization token and
+  without needing to make another request,
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test """
+           the plug pipeline responds and is not halted
+         """,
+         _context do
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{passing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert second_conn.resp_body == "responded"
+    end
+
+    test """
+           an authenticated plug pipeline returns a cleaned private field
+         """,
+         _context do
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{passing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert :ueberauth_token not in second_conn.private
+    end
+
+    test """
+           an authenticated plug pipeline assigns an %Auth{} struct to the conn
+         """,
+         _context do
+      now_unix = DateTime.to_unix(DateTime.utc_now(), :second)
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{passing_token()}")
+        |> TestPlugRouter.call([])
+
+      actual_ueberauth_struct = second_conn.assigns.ueberauth_auth
+      expected_ueberauth_struct = expected_passing_ueberauth_struct(expires_at: now_unix)
+
+      assert :ueberauth_auth in Map.keys(second_conn.assigns)
+      assert actual_ueberauth_struct == expected_ueberauth_struct
+    end
+
+    test "an authenticated plug pipeline returned %Auth{} struct has the expected token",
+         _context do
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{passing_token()}")
+        |> TestPlugRouter.call([])
+
+      actual_ueberauth_token = second_conn.assigns.ueberauth_auth.credentials.token
+
+      assert actual_ueberauth_token == passing_token()
+    end
+  end
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when the request headers have an empty authorization token and
+  without needing to make another request,
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :token
+    @describetag :provider
+
+    test "the plug pipeline raises a TokenParsingError exception", _context do
+      expected_msg = """
+      Error while processing token , only a bearer token is acceptable due\nto original exception: \
+      %MatchError{term: [\"\"]}\n\nExample: \"Bearer 5a236016-07f0-4689-bf74-d7b8559b21d7\"
+      """
+
+      assert_raise TokenParsingError, expected_msg, fn ->
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "")
+        |> TestPlugRouter.call([])
+      end
+    end
+  end
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when the request headers have a failing token and a failed token response
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :token
+    @describetag :provider
+
+    test """
+           the plug pipeline responds and is not halted
+         """,
+         _context do
+      expect_passing_user_info()
+      expect_failing_token_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert second_conn.resp_body == "responded"
+    end
+
+    test """
+           an unauthenticated plug pipeline returns a cleaned private field
+         """,
+         _context do
+      expect_passing_user_info()
+      expect_failing_token_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert :ueberauth_token not in second_conn.private
+    end
+
+    test """
+           an unauthenticated plug pipeline assigns an %Failure{} struct to the conn
+         """,
+         _context do
+      expect_passing_user_info()
+      expect_failing_token_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      actual_ueberauth_struct = second_conn.assigns.ueberauth_failure
+      expected_ueberauth_struct = expected_failing_ueberauth_struct(:token)
+
+      refute :ueberauth_auth in Map.keys(second_conn.assigns)
+      assert :ueberauth_failure in Map.keys(second_conn.assigns)
+      assert actual_ueberauth_struct == expected_ueberauth_struct
+    end
+  end
+
+  describe """
+    When the cache is activated and
+    when the token has been cached and
+    when the request headers have a failing token and a failed user response
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :token
+    @describetag :provider
+
+    test """
+           the plug pipeline responds and is not halted
+         """,
+         _context do
+      expect_failing_user_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert second_conn.resp_body == "responded"
+    end
+
+    test """
+           an unauthenticated plug pipeline returns a cleaned private field
+         """,
+         _context do
+      expect_failing_user_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      assert :ueberauth_token not in second_conn.private
+    end
+
+    test """
+           an unauthenticated plug pipeline assigns an %Failure{} struct to the conn
+         """,
+         _context do
+      expect_failing_user_info()
+
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> Conn.put_req_header("authorization", "Bearer #{failing_token()}")
+        |> TestPlugRouter.call([])
+
+      actual_ueberauth_struct = second_conn.assigns.ueberauth_failure
+      expected_ueberauth_struct = expected_failing_ueberauth_struct(:user)
+
+      refute :ueberauth_auth in Map.keys(second_conn.assigns)
+      assert :ueberauth_failure in Map.keys(second_conn.assigns)
+      assert actual_ueberauth_struct == expected_ueberauth_struct
+    end
+  end
+end

--- a/test/ueberauth_token/with_cache/strategy_test.exs
+++ b/test/ueberauth_token/with_cache/strategy_test.exs
@@ -1,0 +1,130 @@
+defmodule UeberauthToken.WithCache.StrategyTest do
+  use UeberauthToken.TestCase
+  alias Plug.Test
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when a provider has not been set in %Conn{private: %{ueberauth_token: _}}
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test """
+         the handle_callback!/1 function raises a FunctionClauseError
+         """,
+         _context do
+      second_conn = Test.conn(:get, "/api", nil)
+
+      assert_raise FunctionClauseError, fn ->
+        Strategy.handle_callback!(second_conn)
+      end
+    end
+  end
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when the request headers lack an authorization token
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test """
+         the handle_callback!/1 function returns %Conn{assigns: assigns} with a
+         struct in the form %Ueberauth.Failure{errors: errors}
+         """,
+         _context do
+      conn_after =
+        :get
+        |> Test.conn("/api", nil)
+        |> put_provider()
+        |> Strategy.handle_callback!()
+
+      assert Map.has_key?(conn_after.assigns, :ueberauth_failure) == true
+
+      assert :erlang.hd(conn_after.assigns.ueberauth_failure.errors).message ==
+               """
+               Token validation failed for a token against the ueberauth_token_test_provider provider\n. \
+               The authorization request header is missing
+               """
+               |> String.trim_trailing("\n")
+    end
+  end
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when a private %Conn{} field has a valid authorization token
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test """
+         the handle_callback!/1 function returns a conn with a private payload
+         """,
+         _context do
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> put_provider()
+        |> put_private_token("Bearer #{passing_token()}")
+        |> Strategy.handle_callback!()
+
+      expected_payload = Fixtures.payload()
+
+      assert Map.has_key?(second_conn.assigns, :ueberauth_failure) == false
+      assert Map.has_key?(second_conn.private, :ueberauth_token) == true
+
+      assert second_conn.private.ueberauth_token.payload == expected_payload
+    end
+  end
+
+  describe """
+  When the cache is activated and
+  when the token has been cached and
+  when the request headers have an authorization token
+  """ do
+    setup [
+      :setup_activated_cache,
+      :set_mox_from_context,
+      :verify_on_exit!
+    ]
+
+    @describetag :provider
+
+    test """
+         the handle_callback!/1 function returns a conn with a private payload
+         """,
+         _context do
+      second_conn =
+        :get
+        |> Test.conn("/api", nil)
+        |> put_provider()
+        |> Conn.put_req_header("authorization", "Bearer #{passing_token()}")
+        |> Strategy.handle_callback!()
+
+      expected_payload = Fixtures.payload()
+
+      assert Map.has_key?(second_conn.assigns, :ueberauth_failure) == false
+      assert Map.has_key?(second_conn.private, :ueberauth_token) == true
+
+      assert second_conn.private.ueberauth_token.payload == expected_payload
+    end
+  end
+end


### PR DESCRIPTION
What does this MR do ?

- Verify that a token is not cached for failed auth and is cached for successful auth

Note: Review after #4