### PR TITLE
Fix crash on timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 ## Description
 
-
 UeberauthToken is a library which helps validate an oauth2 token received by the resource
 server. The token should be validated against the authorization server and an ueberauth struct
 constructed.
 
 ## Features
-
 
 - Helper function to validate the oauth2 token in a request to a resource server
 - Plug to validate the oauth2 token in a request to a resource server
@@ -18,7 +16,6 @@ constructed.
 ## Prerequisites
 
 - Definition of a provider module which implements the following callbacks
-
 
 ```elixir
 @callback get_payload(token :: String.t(), opts :: list()) :: {:ok, map()} | {:error, map()}
@@ -102,7 +99,7 @@ config :ueberauth_token, SomeProvider,
   background_frequency: 600,
   background_worker_log_level: :warn
 ```
-    
+
 *Note:* The configuration also supports [confex](https://hex.pm/packages/confex) style configurations.
 
 ## Tests
@@ -110,14 +107,13 @@ config :ueberauth_token, SomeProvider,
 ```elixir
 MIX_ENV=test mix test
 ```
-    
+
 ## Authors
 
-
 - Stephen Moloney (*[Stephen Moloney](https://github.com/stephenmoloney)*)
+- Ian Vaughan (*[Ian Vaughan](https://github.com/ianvaughan)*)
 
 ## License
-
 
 MIT License.
 See [LICENSE.md](https://github.com/QuiqUpLTD/ueberauth_token/blob/master/LICENSE.md) for further details.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-if Mix.env() == :test do
+if Mix.env() == :test || Mix.env() == :dev do
   config :ueberauth_token, UeberauthToken.Config,
     providers: {:system, :list, "TEST_TOKEN_PROVIDER", [UeberauthToken.TestProvider]}
 

--- a/lib/ueberauth_token/supervisor.ex
+++ b/lib/ueberauth_token/supervisor.ex
@@ -3,6 +3,7 @@ defmodule UeberauthToken.Supervisor do
   use Supervisor
   alias UeberauthToken.Config
 
+  @spec start_link(any()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(args \\ []) do
     Confex.resolve_env!(:ueberauth_token)
     check_for_duplicate_cache_names!()

--- a/lib/ueberauth_token/worker.ex
+++ b/lib/ueberauth_token/worker.ex
@@ -17,6 +17,7 @@ defmodule UeberauthToken.Worker do
 
   # public
 
+  @spec start_link(keyword()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(opts \\ []) do
     provider = Keyword.fetch!(opts, :provider)
 
@@ -25,11 +26,13 @@ defmodule UeberauthToken.Worker do
 
   # callbacks
 
+  @spec init(nil | keyword() | map()) :: {:ok, {nil, %{provider: any()}}}
   def init(opts) do
     periodic_checking(opts[:provider])
     {:ok, {nil, %{provider: opts[:provider]}}}
   end
 
+  @spec periodic_checking(atom() | binary()) :: :ok
   def periodic_checking(provider) do
     GenServer.cast(worker_name(provider), :periodic_checking)
   end
@@ -194,6 +197,7 @@ defmodule UeberauthToken.Worker do
     """
   end
 
+  @spec worker_details(atom() | binary()) :: <<_::64, _::_*8>>
   defp worker_details(provider) do
     "worker #{worker_name(provider)} with process_id #{Process.whereis(worker_name(provider))}"
   end

--- a/lib/ueberauth_token/worker.ex
+++ b/lib/ueberauth_token/worker.ex
@@ -191,15 +191,17 @@ defmodule UeberauthToken.Worker do
 
   defp location(%Macro.Env{} = env) do
     """
-    module: #{env.module},
-    function: #{env.function},
-    line: #{env.line}
+    module: #{inspect(env.module)},
+    function: #{inspect(env.function)},
+    line: #{inspect(env.line)}
     """
   end
 
   @spec worker_details(atom() | binary()) :: <<_::64, _::_*8>>
-  defp worker_details(provider) do
-    "worker #{worker_name(provider)} with process_id #{Process.whereis(worker_name(provider))}"
+  def worker_details(provider) do
+    "worker #{worker_name(provider)} with process_id #{
+      inspect(Process.whereis(worker_name(provider)))
+    }"
   end
 
   defp worker_name(provider) do

--- a/lib/ueberauth_token/worker.ex
+++ b/lib/ueberauth_token/worker.ex
@@ -118,8 +118,15 @@ defmodule UeberauthToken.Worker do
   end
 
   defp do_checks(provider) do
-    {:ok, tokens} = Cachex.keys(Config.cache_name(provider))
+    provider
+    |> Config.cache_name()
+    |> Cachex.keys()
+    |> do_checks_with_keys(provider)
+  end
 
+  defp do_checks_with_keys({:error, :no_cache}, _provider), do: nil
+
+  defp do_checks_with_keys({:ok, tokens}, provider) do
     steps =
       tokens
       |> Enum.count()


### PR DESCRIPTION
Escape strings correctly to protect against `protocol String.Chars not implemented` error.

Fixes #8 