### PR TITLE
Fix for require Logger macro error with :erlang.apply

### DIFF
--- a/lib/ueberauth_token/worker.ex
+++ b/lib/ueberauth_token/worker.ex
@@ -10,7 +10,6 @@ defmodule UeberauthToken.Worker do
   See full description of the config options in `UeberauthToken.Config` @moduledoc.
   """
   use GenServer
-  require Logger
   alias UeberauthToken.{CheckSupervisor, Config, Strategy}
 
   @stagger_phases 30

--- a/lib/ueberauth_token/worker.ex
+++ b/lib/ueberauth_token/worker.ex
@@ -78,7 +78,7 @@ defmodule UeberauthToken.Worker do
     #{location(__ENV__)}
     """
 
-    :erlang.apply(Logger, Config.background_worker_log_level(provider), [msg])
+    :erlang.apply(Logger, :bare_log, [Config.background_worker_log_level(provider), msg])
 
     {:noreply, {timer, state}}
   end
@@ -89,7 +89,7 @@ defmodule UeberauthToken.Worker do
     #{location(__ENV__)}
     """
 
-    :erlang.apply(Logger, Config.background_worker_log_level(provider), [msg])
+    :erlang.apply(Logger, :bare_log, [Config.background_worker_log_level(provider), msg])
 
     :ok
   end


### PR DESCRIPTION
What does this commit/MR/PR do?

- Should fix #15 

- This issue is well described in `https://github.com/elixir-lang/elixir/issues/7740`

- Switches to invocation of a function at runtime instead of a macro
for Logger

- Use `Logger.bare_log` in place of `Logger.macro`

Why is this commit/MR/PR needed?

- To avoid errors emanating from the worker during termination